### PR TITLE
Enum item access

### DIFF
--- a/backend/apps/ifc_validation/checks/check_gherkin.py
+++ b/backend/apps/ifc_validation/checks/check_gherkin.py
@@ -11,7 +11,7 @@ def perform(ifc_fn, task_id, rule_type, verbose):
 
     try:
         
-        gherkin_rule_type = gherkin_rules.RuleType.from_argv(rule_type)
+        gherkin_rule_type = gherkin_rules.RuleType[rule_type]
         rules_run = gherkin_rules.run(
             filename=ifc_fn,
             rule_type=gherkin_rule_type,


### PR DESCRIPTION
I think this causes the behaviour we discussed where all rule types were being checked regardless of task type. `from_argv()` was intended to load sth like `--informal-propositions` not a string that was already formatted like the actual enum member `INFORMAL_PROPOSITIONS`.