### PR TITLE
map Postgres DB port in infra_only Docker compose file

### DIFF
--- a/docker-compose.infra_only.yml
+++ b/docker-compose.infra_only.yml
@@ -23,8 +23,8 @@ services:
             POSTGRES_DB: ${POSTGRES_NAME}
             POSTGRES_USER: ${POSTGRES_USER}
             POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-        expose:
-            - ${POSTGRES_PORT}
+        ports:
+            - ${POSTGRES_PORT}:${POSTGRES_PORT}
 
     # Celery flower
     flower:


### PR DESCRIPTION
map Postgres DB port in infra_only Docker compose file (re. discussion with Scott earlier this week)