### PR TITLE
only include valid/invalid/warning report sections in completion email

### DIFF
--- a/backend/apps/ifc_validation/email_tasks.py
+++ b/backend/apps/ifc_validation/email_tasks.py
@@ -12,6 +12,11 @@ from apps.ifc_validation_models.models import ValidationRequest
 logger = get_task_logger(__name__)
 
 
+def status_combine(*args):
+    statuses = "-pvnwi"
+    return statuses[max(map(statuses.index, args))]
+
+
 @shared_task
 @log_execution
 def send_acknowledgement_user_email_task(id, file_name):
@@ -141,6 +146,17 @@ def send_completion_email_task(id, file_name):
     merge_data = { 
         'FILE_NAME': file_name,
         'ID': id,
+        'STATUS_SYNTAX': ("p" if (request.model is None or request.model.status_syntax is None) else request.model.status_syntax) in ['v', 'w', 'i'],
+        "STATUS_SCHEMA": status_combine(
+            "p" if (request.model is None or request.model.status_schema is None) else request.model.status_schema,
+            "p" if (request.model is None or request.model.status_prereq is None) else request.model.status_prereq
+        ) in ['v', 'w', 'i'],
+        "STATUS_BSDD": ("p" if (request.model is None or request.model.status_bsdd is None) else request.model.status_bsdd) in ['v', 'w', 'i'],
+        "STATUS_RULES": status_combine(
+            "p" if (request.model is None or request.model.status_ia is None) else request.model.status_ia,
+            "p" if (request.model is None or request.model.status_ip is None)  else request.model.status_ip
+        ) in ['v', 'w', 'i'],
+        "STATUS_IND": ("p" if (request.model is None or request.model.status_industry_practices is None) else request.model.status_industry_practices) in ['v', 'w', 'i'],
         'PUBLIC_URL': PUBLIC_URL,
         'CONTACT_EMAIL': CONTACT_EMAIL
     }

--- a/backend/apps/ifc_validation/templates/validation_completed_email.html
+++ b/backend/apps/ifc_validation/templates/validation_completed_email.html
@@ -11,11 +11,21 @@
             The validation reports can be found here:    
             <ul>
                 <li><a href="{{PUBLIC_URL}}/report_file/{{ID}}">File Metrics</a></li>
+                {% if STATUS_SYNTAX %}
                 <li><a href="{{PUBLIC_URL}}/report_syntax/{{ID}}">STEP Syntax</a></li>
+                {% endif %}
+                {% if STATUS_SCHEMA %}
                 <li><a href="{{PUBLIC_URL}}/report_schema/{{ID}}">IFC Schema</a></li>
+                {% endif %}
+                {% if STATUS_RULES %}
                 <li><a href="{{PUBLIC_URL}}/report_rules/{{ID}}">Normative IFC Rules</a></li>
+                {% endif %}
+                {% if STATUS_IND %}
                 <li><a href="{{PUBLIC_URL}}/report_industry/{{ID}}">Industry Practices</a></li>
+                {% endif %}
+                {% if STATUS_BSDD %}
                 <li><a href="{{PUBLIC_URL}}/report_bsdd/{{ID}}">bSDD Compliance</a></li>
+                {% endif %}
             </ul>
             Please report any bugs/inconsistencies/comments to <a href="mailto:{{CONTACT_EMAIL}}">{{CONTACT_EMAIL}}</a>.<br>
             <br>


### PR DESCRIPTION
only include valid/invalid/warning report sections (now mirrors the status of the dashboard)