### PR TITLE
disable whitelist in PRODUCTION

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -30,7 +30,9 @@ SECRET_KEY = os.environ.get(
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", False)
-DEVELOPMENT = os.environ.get('ENV', 'PROD').upper() in ('DEV', 'DEVELOPMENT')
+DEVELOPMENT = os.environ.get('ENV', 'PROD').upper() in ('DEV', 'DEVELOP', 'DEVELOPMENT')
+STAGING = os.environ.get('ENV', 'PROD').upper() in ('STAGE', 'STAGING', 'QA')
+PRODUCTION = os.environ.get('ENV', 'PROD').upper() in ('PROD', 'PRODUCTION', 'PRD')
 PUBLIC_URL = os.getenv('PUBLIC_URL').strip('/') if os.getenv('PUBLIC_URL') is not None else None
 
 ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "localhost", "backend"]

--- a/backend/core/views_auth.py
+++ b/backend/core/views_auth.py
@@ -11,7 +11,7 @@ from requests.models import PreparedRequest
 from authlib.integrations.django_client import OAuth
 
 from .email_tasks import send_user_registered_admin_email_task
-from .settings import LOGIN_CALLBACK_URL, POST_LOGIN_REDIRECT_URL, LOGOUT_URL, LOGIN_URL, DEVELOPMENT
+from .settings import LOGIN_CALLBACK_URL, POST_LOGIN_REDIRECT_URL, LOGOUT_URL, LOGIN_URL, PRODUCTION
 
 oauth = OAuth()
 oauth.register(name="b2c")

--- a/backend/core/views_auth.py
+++ b/backend/core/views_auth.py
@@ -11,7 +11,7 @@ from requests.models import PreparedRequest
 from authlib.integrations.django_client import OAuth
 
 from .email_tasks import send_user_registered_admin_email_task
-from .settings import LOGIN_CALLBACK_URL, POST_LOGIN_REDIRECT_URL, LOGOUT_URL, LOGIN_URL
+from .settings import LOGIN_CALLBACK_URL, POST_LOGIN_REDIRECT_URL, LOGOUT_URL, LOGIN_URL, DEVELOPMENT
 
 oauth = OAuth()
 oauth.register(name="b2c")
@@ -51,7 +51,7 @@ def callback(request):
                 username = username,
                 password = username,
                 email = userinfo['email'],
-                is_active = False, 
+                is_active = True if PRODUCTION else False, 
                 is_superuser = False,
                 is_staff = False,
                 first_name = userinfo['given_name'],


### PR DESCRIPTION
Kept whitelisting of users (aka creating user accounts but setting is_active to False) for non-PRODUCTION environments