### PR TITLE
VAL-340 - Allow sorting on FileSize field in Django Admin

### DIFF
--- a/backend/apps/ifc_validation/admin.py
+++ b/backend/apps/ifc_validation/admin.py
@@ -281,7 +281,7 @@ class ModelAdmin(BaseAdmin, NonAdminAddable):
         
         return None if obj.number_of_properties is None else f'{obj.number_of_properties:,}'
 
-    @admin.display(description=, ordering='size')
+    @admin.display(description="File Size", ordering='size')
     def size_text(self, obj):
         
         return utils.format_human_readable_file_size(obj.size)

--- a/backend/apps/ifc_validation/admin.py
+++ b/backend/apps/ifc_validation/admin.py
@@ -73,7 +73,7 @@ class ValidationRequestAdmin(BaseAdmin, NonAdminAddable):
 
         return ("Yes" if obj.deleted else "No")
 
-    @admin.display(description="File Size")
+    @admin.display(description="File Size", ordering='size')
     def file_size_text(self, obj):
 
         return utils.format_human_readable_file_size(obj.size)

--- a/backend/apps/ifc_validation/admin.py
+++ b/backend/apps/ifc_validation/admin.py
@@ -281,7 +281,7 @@ class ModelAdmin(BaseAdmin, NonAdminAddable):
         
         return None if obj.number_of_properties is None else f'{obj.number_of_properties:,}'
 
-    @admin.display(description="File Size")
+    @admin.display(description=, ordering='size')
     def size_text(self, obj):
         
         return utils.format_human_readable_file_size(obj.size)


### PR DESCRIPTION
Allow sorting on FileSize field in Django Admin - one-line fix