### PR TITLE
VAL-409 - Replace redundant email with user full name

### DIFF
--- a/backend/apps/ifc_validation/email_tasks.py
+++ b/backend/apps/ifc_validation/email_tasks.py
@@ -56,6 +56,7 @@ def send_acknowledgement_admin_email_task(id, file_name):
     merge_data = { 
         'NUMBER_OF_FILES': 1,
         'FILE_NAMES': file_name,
+        # From django docs: Returns the first_name plus the last_name, with a space in between.
         'USER_FULL_NAME': user.get_full_name(),
         'USER_EMAIL': user.email,
         'PUBLIC_URL': PUBLIC_URL

--- a/backend/apps/ifc_validation/email_tasks.py
+++ b/backend/apps/ifc_validation/email_tasks.py
@@ -56,7 +56,7 @@ def send_acknowledgement_admin_email_task(id, file_name):
     merge_data = { 
         'NUMBER_OF_FILES': 1,
         'FILE_NAMES': file_name,
-        'USER_NAME': user.username,
+        'USER_FULL_NAME': user.get_full_name(),
         'USER_EMAIL': user.email,
         'PUBLIC_URL': PUBLIC_URL
     }
@@ -115,7 +115,7 @@ def send_revalidating_admin_email_task(id, file_name):
     merge_data = { 
         'NUMBER_OF_FILES': 1,
         'FILE_NAMES': file_name,
-        'USER_NAME': user.username,
+        'USER_FULL_NAME': user.get_full_name(),
         'USER_EMAIL': user.email,
         'PUBLIC_URL': PUBLIC_URL
     }

--- a/backend/apps/ifc_validation/templates/validation_ack_admin_email.html
+++ b/backend/apps/ifc_validation/templates/validation_ack_admin_email.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <div>
-            {{NUMBER_OF_FILES}} file(s) were uploaded by user {{USER_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}
+            {{NUMBER_OF_FILES}} file(s) were uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}
         </div>
     </body>
 </html>

--- a/backend/apps/ifc_validation/templates/validation_reval_admin_email.html
+++ b/backend/apps/ifc_validation/templates/validation_reval_admin_email.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <div>
-            Request for revalidation of {{NUMBER_OF_FILES}} file(s) previously uploaded by user {{USER_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}            
+            Request for revalidation of {{NUMBER_OF_FILES}} file(s) previously uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}            
         </div>
     </body>
 </html>


### PR DESCRIPTION
Simple fix - replace 

[email] ([email]) - eg. john@doe.net (john@doe.net)

   with 

[user full name] ([email] - eg. John Doe (john@doe.net)