### PR TITLE
End feature description parsing at 'Scenario Outline:'

### DIFF
--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -142,7 +142,7 @@ def get_feature_description(feature_code, feature_version):
                 for line in input:
                     if 'Feature:' in line:
                         reading = True
-                    if 'Scenario:' in line or 'Background:' in line:
+                    if any(keyword in line for keyword in ['Scenario:', 'Background:', 'Scenario Outline:']):
                         return gherkin_desc
                     if reading and len(line.strip()) > 0 and 'Feature:' not in line and '@' not in line: 
                         gherkin_desc += '\n' + line.strip()


### PR DESCRIPTION
With the adjusted line the parsing will include 'Scenario Outline:'
![image](https://github.com/buildingSMART/validate/assets/54070862/0373c2ac-3c17-4b11-bb40-41e723b908e3)

Handling `SPS007` parsing 
![image](https://github.com/buildingSMART/validate/assets/54070862/911de055-fb6c-4863-99ca-664f512667bf)

So then only the following line would be displayed as the description: 

`The rule verifies that spatial containment via IfcRelContainedInSpatialStructure is utilised in accordance with Contept Template for Spatial Containment`