### PR TITLE
IVS-13 clearer message for critical error

### DIFF
--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -406,7 +406,6 @@ def report(request, id: str):
         task = ValidationTask.objects.filter(request_id=request.id, type=ValidationTask.Type.SYNTAX).last()
         if task.outcomes:
             for outcome in task.outcomes.iterator():
-
                 # TODO - should we not do this in the model?
                 match = re.search('^On line ([0-9])+ column ([0-9])+(.)*', outcome.observed)                
                 mapped = {
@@ -414,7 +413,7 @@ def report(request, id: str):
                     "lineno": match.groups()[0] if match and len(match.groups()) > 0 else None,
                     "column": match.groups()[1] if match and len(match.groups()) > 1 else None,
                     "severity": outcome.severity,
-                    "msg": outcome.observed,
+                    "msg": f"expected: {outcome.expected}, observed: {outcome.observed}" if getattr(outcome, 'expected', None) is not None else outcome.observed,
                     "task_id": outcome.validation_task_public_id
                 }
                 syntax_results.append(mapped)


### PR DESCRIPTION
Clearer message by also including the expected column in case errors due to the `@critical `tag.

In the case of IFC101, this would be
`{"oneOf": ["IFC4X3_ADD2", "IFC4", "IFC2X3"]} `

Alternatively, we can come up with something nicer for displaying these kind of messages, such as:
- Displaying the rule in the `normative rules` column as the only error. 
- Custom messaging for rules with a `critical` tag. For instance, include the feature description. 
![image (1)](https://github.com/buildingSMART/validate/assets/54070862/36cb8678-7621-488b-aa36-6f7119bd11b5)
