### PR TITLE
Use ast.literal_eval rather than eval()

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import logging
+import ast
 
 from dotenv import load_dotenv
 from pathlib import Path
@@ -360,7 +361,7 @@ LOGIN_CALLBACK_URL = os.environ.get("CALLBACK_URL", f"{PUBLIC_URL}/callback")
 POST_LOGIN_REDIRECT_URL = os.environ.get("POST_LOGIN_REDIRECT_URL", f"{PUBLIC_URL}/dashboard")
 
 # whitelisting of users
-USE_WHITELIST = eval(os.environ.get("USE_WHITELIST", False))
+USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", False))
 
 AUTHLIB_OAUTH_CLIENTS = {
     'b2c': {

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -361,7 +361,8 @@ LOGIN_CALLBACK_URL = os.environ.get("CALLBACK_URL", f"{PUBLIC_URL}/callback")
 POST_LOGIN_REDIRECT_URL = os.environ.get("POST_LOGIN_REDIRECT_URL", f"{PUBLIC_URL}/dashboard")
 
 # whitelisting of users
-USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", False))
+USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", 'False'))
+
 
 AUTHLIB_OAUTH_CLIENTS = {
     'b2c': {


### PR DESCRIPTION
As per [the comment on the previous PR](https://github.com/buildingSMART/validate/pull/84#discussion_r1690612156)
> `eval` cannot operate on boolean values so the default to get() needs to be a string as well. Also `eval` is probably not very safe, better use `ast.literal_eval()`

See also the[ dangers of ast](http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html)

