### PR TITLE
Small updates for local deployment

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,20 +15,50 @@ install: venv
 	pip install -r requirements.txt && \
     wget -O /tmp/ifcopenshell_python.zip "https://s3.amazonaws.com/ifcopenshell-builds/ifcopenshell-python-311-v0.7.0-742a9ec-linux64.zip" && \
     mkdir -p $(VIRTUAL_ENV)/lib/python3.11/site-packages && \
-    unzip -f -d $(VIRTUAL_ENV)/lib/python3.11/site-packages /tmp/ifcopenshell_python.zip && \
+    unzip /tmp/ifcopenshell_python.zip -d $(VIRTUAL_ENV)/lib/python3.11/site-packages && \
 	rm /tmp/ifcopenshell_python.zip
 
 fetch-modules:
 	cd ./apps && \
 	git submodule update --init --recursive
 
-start-django: start-backend
+start-django: fetch-modules start-backend
+
+start-django-no-fetch: start-backend
 
 start-backend:
 	. $(VIRTUAL_ENV)/bin/activate && \
 	python3 manage.py makemigrations && \
 	python3 manage.py migrate && \
 	python3 manage.py runserver
+
+IFC_VALIDATION_MODELS_DIR=apps/ifc_validation_models
+IFC_GHERKIN_RULES_DIR=apps/ifc_validation/checks/ifc_gherkin_rules
+
+SUBMODULE_IFC_VALIDATION_MODELS=ifc_validation_models
+SUBMODULE_IFC_GHERKIN_RULES=ifc_gherkin_rules
+
+# Update submodule and checkout specific branch
+# e.g. 'make update-submodule submodule=ifc_gherkin_rules branch=development'
+update-submodule:
+	@if [ "$(submodule)" = "$(SUBMODULE_IFC_VALIDATION_MODELS)" ]; then \
+		echo "Matches IFC Validation Models"; \
+		eval SUBMODULE_DIR=$(IFC_VALIDATION_MODELS_DIR); \
+	elif [ "$(submodule)" = "$(SUBMODULE_IFC_GHERKIN_RULES)" ]; then \
+		echo "Matches IFC Gherkin Rules"; \
+		eval SUBMODULE_DIR=$(IFC_GHERKIN_RULES_DIR); \
+	else \
+		echo "Unknown submodule '$(submodule)'. Please specify 'ifc_validation_models' or 'ifc_gherkin_rules'."; \
+		exit 1; \
+	fi; \
+	cd $$SUBMODULE_DIR && git fetch; \
+	if git show-ref --verify --quiet refs/heads/$(branch); then \
+		git checkout $(branch) && git pull; \
+	else \
+		echo "else reached"; \
+		git checkout $(branch) && git pull; \
+	fi
+
 
 start-worker:
 	. $(VIRTUAL_ENV)/bin/activate && \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -42,10 +42,8 @@ SUBMODULE_IFC_GHERKIN_RULES=ifc_gherkin_rules
 # e.g. 'make update-submodule submodule=ifc_gherkin_rules branch=development'
 update-submodule:
 	@if [ "$(submodule)" = "$(SUBMODULE_IFC_VALIDATION_MODELS)" ]; then \
-		echo "Matches IFC Validation Models"; \
 		eval SUBMODULE_DIR=$(IFC_VALIDATION_MODELS_DIR); \
 	elif [ "$(submodule)" = "$(SUBMODULE_IFC_GHERKIN_RULES)" ]; then \
-		echo "Matches IFC Gherkin Rules"; \
 		eval SUBMODULE_DIR=$(IFC_GHERKIN_RULES_DIR); \
 	else \
 		echo "Unknown submodule '$(submodule)'. Please specify 'ifc_validation_models' or 'ifc_gherkin_rules'."; \
@@ -55,7 +53,6 @@ update-submodule:
 	if git show-ref --verify --quiet refs/heads/$(branch); then \
 		git checkout $(branch) && git pull; \
 	else \
-		echo "else reached"; \
 		git checkout $(branch) && git pull; \
 	fi
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,7 +24,7 @@ fetch-modules:
 
 start-django: fetch-modules start-backend
 
-start-django-no-fetch: start-backend
+start-django-skip-fetch: start-backend
 
 start-backend:
 	. $(VIRTUAL_ENV)/bin/activate && \

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 
 import os
 import logging
+import ast
 
 from dotenv import load_dotenv
 from pathlib import Path
@@ -360,7 +361,7 @@ LOGIN_CALLBACK_URL = os.environ.get("CALLBACK_URL", f"{PUBLIC_URL}/callback")
 POST_LOGIN_REDIRECT_URL = os.environ.get("POST_LOGIN_REDIRECT_URL", f"{PUBLIC_URL}/dashboard")
 
 # whitelisting of users
-USE_WHITELIST = eval(os.environ.get("USE_WHITELIST", False))
+USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", False))
 
 AUTHLIB_OAUTH_CLIENTS = {
     'b2c': {

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -361,7 +361,8 @@ LOGIN_CALLBACK_URL = os.environ.get("CALLBACK_URL", f"{PUBLIC_URL}/callback")
 POST_LOGIN_REDIRECT_URL = os.environ.get("POST_LOGIN_REDIRECT_URL", f"{PUBLIC_URL}/dashboard")
 
 # whitelisting of users
-USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", False))
+USE_WHITELIST = ast.literal_eval(os.environ.get("USE_WHITELIST", 'False'))
+
 
 AUTHLIB_OAUTH_CLIENTS = {
     'b2c': {

--- a/docker-compose.infra_only.yml
+++ b/docker-compose.infra_only.yml
@@ -34,7 +34,7 @@ services:
             CELERY_BROKER_URL: ${CELERY_BROKER_URL}
             TASK_COLUMNS: "name,uuid,state,args,kwargs,result,received,started,runtime,worker,retries,revoked,exception,eta"
             FLOWER_PORT: 5555
-            FLOWER_UNAUTHENTICATED_API: true
+            FLOWER_UNAUTHENTICATED_API: "true"
         ports:
             - 5555:5555
         depends_on:


### PR DESCRIPTION
- Changed FLOWER_UNAUTHENTICATED_API value from a boolean to a string literal. Boolean seems only to be used in .env files 
- IfcOpenShell was not correctly placed in the site-packages folder (causing some problems with imports). 
- When running locally, also fetch the submodules on make` start-django`. If this is not desired behavior, run 'start-django-skip-fetch' 
- Create Makefile's `update-submodule` target to fetch and checkout specified branches for submodules