### PR TITLE
IVS-235 - update Instance Completion task + update admin

### DIFF
--- a/backend/apps/ifc_validation/admin.py
+++ b/backend/apps/ifc_validation/admin.py
@@ -298,9 +298,9 @@ class ModelAdmin(BaseAdmin, NonAdminAddable):
 
 class ModelInstanceAdmin(BaseAdmin, NonAdminAddable):
 
-    list_display = ["id", "public_id", "stepfile_id", "model", "ifc_type", "created", "updated"]
-
+    list_display = ["id", "public_id", "model", "model_id", "stepfile_id", "ifc_type", "created", "updated"]
     search_fields = ('stepfile_id', 'model__file_name', 'ifc_type')
+    list_filter = ["ifc_type", "model_id", "created", "updated"]
 
 
 class CompanyAdmin(BaseAdmin):


### PR DESCRIPTION
- only fetch/update `ModelInstance` records that require updating - for some reason `.bulk_update()` fails...
- promote `Instance_completion_subtask` into proper `ValidationTask` (to be able to track in UI)
- update `ModelInstance` admin screen