### PR TITLE
IVS-395 - Include environment in admin emails (low prio)

### DIFF
--- a/backend/apps/ifc_validation/email_tasks.py
+++ b/backend/apps/ifc_validation/email_tasks.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 from core.utils import log_execution
 from core.utils import send_email
 from core.utils import get_title_from_html
-from core.settings import PUBLIC_URL, ADMIN_EMAIL, CONTACT_EMAIL
+from core.settings import PUBLIC_URL, ADMIN_EMAIL, CONTACT_EMAIL, ENVIRONMENT
 
 from apps.ifc_validation_models.models import ValidationRequest
 
@@ -56,14 +56,14 @@ def send_acknowledgement_admin_email_task(id, file_name):
     merge_data = { 
         'NUMBER_OF_FILES': 1,
         'FILE_NAMES': file_name,
-        # From django docs: Returns the first_name plus the last_name, with a space in between.
         'USER_FULL_NAME': user.get_full_name(),
         'USER_EMAIL': user.email,
-        'PUBLIC_URL': PUBLIC_URL
+        'PUBLIC_URL': PUBLIC_URL,
+        'ENVIRONMENT': ENVIRONMENT
     }
     to = ADMIN_EMAIL
     body_html = render_to_string("validation_ack_admin_email.html", merge_data)
-    body_text = f"User uploaded {{merge_data.NUMBER_OF_FILES}} file(s)."
+    body_text = f"User uploaded {{merge_data.NUMBER_OF_FILES}} file(s) in {{merge_data.ENVIRONMENT}}."
     subject = get_title_from_html(body_html)
 
     # queue for sending
@@ -118,11 +118,12 @@ def send_revalidating_admin_email_task(id, file_name):
         'FILE_NAMES': file_name,
         'USER_FULL_NAME': user.get_full_name(),
         'USER_EMAIL': user.email,
-        'PUBLIC_URL': PUBLIC_URL
+        'PUBLIC_URL': PUBLIC_URL,
+        'ENVIRONMENT': ENVIRONMENT
     }
     to = ADMIN_EMAIL
     body_html = render_to_string("validation_reval_admin_email.html", merge_data)
-    body_text = f"Revalidating {{merge_data.NUMBER_OF_FILES}} file(s)."
+    body_text = f"Revalidating {{merge_data.NUMBER_OF_FILES}} file(s) in {{merge_data.ENVIRONMENT}}."
     subject = get_title_from_html(body_html)
 
     # queue for sending

--- a/backend/apps/ifc_validation/templates/validation_ack_admin_email.html
+++ b/backend/apps/ifc_validation/templates/validation_ack_admin_email.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <div>
-            {{NUMBER_OF_FILES}} file(s) were uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}
+            {{NUMBER_OF_FILES}} file(s) were uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}} in {{ENVIRONMENT}}.
         </div>
     </body>
 </html>

--- a/backend/apps/ifc_validation/templates/validation_reval_admin_email.html
+++ b/backend/apps/ifc_validation/templates/validation_reval_admin_email.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <div>
-            Request for revalidation of {{NUMBER_OF_FILES}} file(s) previously uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}}            
+            Request for revalidation of {{NUMBER_OF_FILES}} file(s) previously uploaded by {{USER_FULL_NAME}} ({{USER_EMAIL}}): {{FILE_NAMES}} in {{ENVIRONMENT}}.     
         </div>
     </body>
 </html>

--- a/backend/core/email_tasks.py
+++ b/backend/core/email_tasks.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 from .utils import log_execution
 from .utils import send_email
 from .utils import get_title_from_html
-from .settings import PUBLIC_URL, ADMIN_EMAIL
+from .settings import PUBLIC_URL, ADMIN_EMAIL, ENVIRONMENT
 
 logger = get_task_logger(__name__)
 
@@ -20,11 +20,12 @@ def send_user_registered_admin_email_task(user_id, user_email, is_active = True)
         'USER_EMAIL': user_email,
         'IS_ACTIVE': is_active,
         'PUBLIC_URL': PUBLIC_URL,
-        'ACTIVATE_URL': PUBLIC_URL + '/admin/auth/user'
+        'ACTIVATE_URL': PUBLIC_URL + '/admin/auth/user',
+        'ENVIRONMENT': ENVIRONMENT
     }
     to = ADMIN_EMAIL
     body_html = render_to_string("user_registered_admin_email.html", merge_data)
-    body_text = f"User {{user_email}} registered for the Validation Service."
+    body_text = f"User {{user_email}} registered for the Validation Service in {{merge_data.ENVIRONMENT}}."
     subject = get_title_from_html(body_html)
 
     # queue for sending

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -34,6 +34,7 @@ DEBUG = os.environ.get("DEBUG", False)
 DEVELOPMENT = os.environ.get('ENV', 'PROD').upper() in ('DEV', 'DEVELOP', 'DEVELOPMENT')
 STAGING = os.environ.get('ENV', 'PROD').upper() in ('STAGE', 'STAGING', 'QA')
 PRODUCTION = os.environ.get('ENV', 'PROD').upper() in ('PROD', 'PRODUCTION', 'PRD')
+ENVIRONMENT = 'DEVELOPMENT' if DEVELOPMENT else 'STAGING' if STAGING else 'PRODUCTION'
 PUBLIC_URL = os.getenv('PUBLIC_URL').strip('/') if os.getenv('PUBLIC_URL') is not None else None
 
 # URL for rule hyperlinks; by default points to bSI Gherkin Rules repo (main)

--- a/backend/core/templates/user_registered_admin_email.html
+++ b/backend/core/templates/user_registered_admin_email.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <div>
-            User {{USER_EMAIL}} registered for the Validation Service @ {{PUBLIC_URL}}{% if not IS_ACTIVE %} and can be activated <a href="{{ACTIVATE_URL}}">here</a>{% endif %}.
+            User {{USER_EMAIL}} registered for the Validation Service @ {{PUBLIC_URL}} in {{ENVIRONMENT}}{% if not IS_ACTIVE %} and can be activated <a href="{{ACTIVATE_URL}}">here</a>{% endif %}.
         </div>
     </body>
 </html>


### PR DESCRIPTION
Not impacting end users, only admin emails will have the name of the environment included in the body of the email