### PR TITLE
IVS-429 - Fetch correct description (url)

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -36,8 +36,11 @@ STAGING = os.environ.get('ENV', 'PROD').upper() in ('STAGE', 'STAGING', 'QA')
 PRODUCTION = os.environ.get('ENV', 'PROD').upper() in ('PROD', 'PRODUCTION', 'PRD')
 PUBLIC_URL = os.getenv('PUBLIC_URL').strip('/') if os.getenv('PUBLIC_URL') is not None else None
 
-# URL for rule hyperlinks; by default points to bSI Gherkin Rules repo (main)
-FEATURE_URL = os.getenv('FEATURE_URL', 'https://github.com/buildingSMART/ifc-gherkin-rules/blob/main/features/')
+# URL for rule hyperlinks; determine the branch based on the environment
+FEATURE_BRANCH = "development" if DEVELOPMENT else "main"
+FEATURE_URL = os.getenv(
+    "FEATURE_URL", f"https://github.com/buildingSMART/ifc-gherkin-rules/blob/{FEATURE_BRANCH}/features/rules"
+)
 
 # Max. number of outcomes shown in UI
 MAX_OUTCOMES_PER_RULE = 10


### PR DESCRIPTION
Because of the gherkin repo refactoring, the url for fetching description information was not correct anymore. 

I'm also dynamically pointing to the `development` or `main` branches. The downside to this is that the url will be incorrect as long as we haven't merged the future release/0.7.1 branch back into main. Is it worth the effort to point to the relevant release branch instead of main to avoid this?