### PR TITLE
IVS-504 - Fix DEBUG mode

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = os.environ.get(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", False)
+DEBUG = ast.literal_eval(os.environ.get("DEBUG", 'False'))
 DEVELOPMENT = os.environ.get('ENV', 'PROD').upper() in ('DEV', 'DEVELOP', 'DEVELOPMENT')
 STAGING = os.environ.get('ENV', 'PROD').upper() in ('STAGE', 'STAGING', 'QA')
 PRODUCTION = os.environ.get('ENV', 'PROD').upper() in ('PROD', 'PRODUCTION', 'PRD')


### PR DESCRIPTION
Correctly parse DEBUG environment variable - will not render stacktrace etc
(we also used `ast.literal_eval` with USE_WHITELIST)

https://docs.djangoproject.com/en/dev/ref/settings/#debug