### PR TITLE
IVS-488 - FIX: Postgres DB isn't really ready

### DIFF
--- a/docker/backend/server-entrypoint.sh
+++ b/docker/backend/server-entrypoint.sh
@@ -11,10 +11,10 @@ do
     echo "Waiting for server volume..."
 done
 
-while ! nc -z ${POSTGRES_HOST} ${POSTGRES_PORT}
+while ! pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -d "$POSTGRES_NAME" -U "$POSTGRES_USER" 2>/dev/null
 do
     echo "Waiting for DB to be ready..."
-    sleep 3
+    sleep 5
 done
 echo "DB is ready."
 

--- a/docker/backend/worker-entrypoint.sh
+++ b/docker/backend/worker-entrypoint.sh
@@ -11,10 +11,10 @@ do
     echo "Waiting for server volume..."
 done
 
-while ! nc -z ${POSTGRES_HOST} ${POSTGRES_PORT}
+while ! pg_isready -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -d "$POSTGRES_NAME" -U "$POSTGRES_USER" 2>/dev/null
 do
     echo "Waiting for DB to be ready..."
-    sleep 3
+    sleep 5
 done
 echo "DB is ready."
 


### PR DESCRIPTION
replaced `nc` with `pg_isready`

more reliable as `pg_isready` checks more than just the network connectivity
https://www.postgresql.org/docs/current/app-pg-isready.html