### PR TITLE
IVS-514 - Unable to download files in Django Admin when DEBUG = False

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -46,6 +46,7 @@ start-backend:
 	. $(VIRTUAL_ENV)/bin/activate && \
 	python3 manage.py makemigrations && \
 	python3 manage.py migrate && \
+	python3 manage.py collectstatic --noinput && \
 	python3 manage.py runserver
 
 start-worker:

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -2,6 +2,7 @@ import re
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.contrib.auth.decorators import login_required
+from django.contrib.admin.views.decorators import staff_member_required
 from django.views.static import serve
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
@@ -43,7 +44,7 @@ urlpatterns = [
 urlpatterns += [
     re_path(
         r"^%s(?P<path>.*)$" % re.escape(MEDIA_URL.lstrip("/")),
-        login_required(serve),
+        login_required(staff_member_required(serve)),
         kwargs={"document_root": MEDIA_ROOT},
     ),
 ]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,6 +1,7 @@
 import re
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.contrib.auth.decorators import login_required
 from django.views.static import serve
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
@@ -37,12 +38,12 @@ urlpatterns = [
     path("__debug__/",       include("debug_toolbar.urls")),
 ]
 
-# serve uploaded files
+# securely serve uploaded files
 # note: Django's default static() only works in DEBUG mode
 urlpatterns += [
     re_path(
         r"^%s(?P<path>.*)$" % re.escape(MEDIA_URL.lstrip("/")),
-        serve,
+        login_required(serve),
         kwargs={"document_root": MEDIA_ROOT},
     ),
 ]

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,12 +1,14 @@
+import re
 from django.contrib import admin
-from django.urls import include, path
-from django.conf.urls.static import static
+from django.urls import include, path, re_path
+from django.views.static import serve
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from .views_auth import login, logout, callback, whoami
 
 from core.settings import MEDIA_ROOT, MEDIA_URL, STATIC_URL, STATIC_ROOT
+
 
 urlpatterns = [
 
@@ -35,8 +37,22 @@ urlpatterns = [
     path("__debug__/",       include("debug_toolbar.urls")),
 ]
 
-# serving uploaded files
-urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)
+# serve uploaded files
+# note: Django's default static() only works in DEBUG mode
+urlpatterns += [
+    re_path(
+        r"^%s(?P<path>.*)$" % re.escape(MEDIA_URL.lstrip("/")),
+        serve,
+        kwargs={"document_root": MEDIA_ROOT},
+    ),
+]
 
 # serve static files
-urlpatterns += static(STATIC_URL, document_root=STATIC_ROOT)
+# note: Django's default static() only works in DEBUG mode
+urlpatterns += [
+    re_path(
+        r"^%s(?P<path>.*)$" % re.escape(STATIC_URL.lstrip("/")),
+        serve,
+        kwargs={"document_root": STATIC_ROOT},
+    ),
+]


### PR DESCRIPTION
replaced `static()` with own `re_path` implementation

Note: Django's static() doesn't work when `DEBUG = False`