### PR TITLE
IVS-529 - Expose Model via API

### DIFF
--- a/backend/apps/ifc_validation/serializers.py
+++ b/backend/apps/ifc_validation/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from apps.ifc_validation_models.models import ValidationRequest
 from apps.ifc_validation_models.models import ValidationTask
 from apps.ifc_validation_models.models import ValidationOutcome
+from apps.ifc_validation_models.models import Model
 
 
 class BaseSerializer(serializers.ModelSerializer):
@@ -48,3 +49,13 @@ class ValidationOutcomeSerializer(BaseSerializer):
         fields = '__all__'
         show = ["public_id", "instance_public_id", "validation_task_public_id"]
         hide = ["id", "instance", "validation_task"]
+
+
+class ModelSerializer(BaseSerializer):
+
+    class Meta:
+        model = Model
+        fields = '__all__'
+        show = ["public_id"]
+        hide = ["id", "number_of_elements", "number_of_geometries", "number_of_properties"] # no longer used
+        read_only_fields = ['',]

--- a/backend/apps/ifc_validation/urls.py
+++ b/backend/apps/ifc_validation/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import ValidationRequestListAPIView, ValidationRequestDetailAPIView
 from .views import ValidationTaskListAPIView, ValidationTaskDetailAPIView
 from .views import ValidationOutcomeListAPIView, ValidationOutcomeDetailAPIView
+from .views import ModelListAPIView, ModelDetailAPIView
 
 urlpatterns = [
     path('validationrequest/',          ValidationRequestListAPIView.as_view()),
@@ -11,4 +12,6 @@ urlpatterns = [
     path('validationtask/<str:id>/',    ValidationTaskDetailAPIView.as_view()),
     path('validationoutcome/',          ValidationOutcomeListAPIView.as_view()),
     path('validationoutcome/<str:id>/', ValidationOutcomeDetailAPIView.as_view()),
+    path('model/',                      ModelListAPIView.as_view()),
+    path('model/<str:id>/',             ModelDetailAPIView.as_view()),
 ]


### PR DESCRIPTION
Before: only `ValidationRequest`, `ValidationTask` and `ValidationOutcome` were accessible via the API
Now: `Model` is also available