### PR TITLE
IVS-587 - Enforce file size limit via API

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -274,6 +274,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Uploaded files
 MAX_FILES_PER_UPLOAD = 100
+MAX_FILE_SIZE_IN_MB = int(os.environ.get("MAX_FILE_SIZE_IN_MB", 256))  # default to 256 MB
 MEDIA_URL = '/files/'
 MEDIA_ROOT = os.environ.get('MEDIA_ROOT', '/files_storage')
 try:

--- a/e2e/fixtures/valid_file.ifc
+++ b/e2e/fixtures/valid_file.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [ReferenceView_V1.2]', 'ExchangeRequirement [Any]'),'2;1');
+FILE_NAME('pass_header_policy.ifc','2025-02-13T15:58:45',('jdoe'),('Acme Inc.'),'ABC rel. 0.1.2','Acme Inc. - MyFabTool - 2025.1','IFC4 model');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPERSON($,$,'',$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+
+const BASE_URL = 'http://localhost:8000';
+const TEST_CREDENTIALS = 'root:root';
+
+test.describe('API - ValidationRequest', () => {
+
+    test('POST accepts valid file', async ({ request }) => {
+
+        // try to post a valid file
+        const file_path = 'e2e/fixtures/valid_file.ifc';
+        const file_name = basename(file_path);
+        const file = new File([readFileSync(file_path)], file_name);
+        const form = new FormData();
+        form.append('file', file);
+        form.append('file_name', file_name);
+
+        let hash = btoa(TEST_CREDENTIALS);
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            },
+            multipart: form
+        });
+
+        // check if the response is correct - 201 Created
+        expect(response.statusText()).toBe('Created');
+        expect(response.status()).toBe(201);
+    });
+
+    test('POST implements file size limit', async ({ request }) => {
+
+        // try to post a large file
+        const file_name = 'very_large_file.ifc';
+        const largeBuffer = Buffer.alloc(300 * 1024 * 1024, 0); // 300 MB of dummy data (> 256 MB limit)
+        const file = new File([largeBuffer], file_name);
+        const form = new FormData();
+        form.append('file', file);
+        form.append('file_name', file_name);
+
+        let hash = btoa(TEST_CREDENTIALS);
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            },
+            multipart: form
+        });
+
+        // check if the response is correct - 413 Payload Too Large
+        expect(response.statusText()).toBe('Request Entity Too Large');
+        expect(response.status()).toBe(413); 
+        expect(await response.json()).toEqual({ message: 'File size exceeds allowed file size limit (256 MB).' });
+    });
+
+});


### PR DESCRIPTION
- enforce file size limit of 256 MB when using the API
- added Playwright tests (positive/negative case)