### PR TITLE
IVS-604 - Reject obvious invalid input for API

### DIFF
--- a/backend/apps/ifc_validation/urls.py
+++ b/backend/apps/ifc_validation/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import path, re_path
 
 from .views import ValidationRequestListAPIView, ValidationRequestDetailAPIView
 from .views import ValidationTaskListAPIView, ValidationTaskDetailAPIView
@@ -11,14 +11,15 @@ from . import chart_views as charts
 urlpatterns = [
 
     # REST API
-    path('validationrequest/',          ValidationRequestListAPIView.as_view()),
-    path('validationrequest/<str:id>/', ValidationRequestDetailAPIView.as_view()),
-    path('validationtask/',             ValidationTaskListAPIView.as_view()),
-    path('validationtask/<str:id>/',    ValidationTaskDetailAPIView.as_view()),
-    path('validationoutcome/',          ValidationOutcomeListAPIView.as_view()),
-    path('validationoutcome/<str:id>/', ValidationOutcomeDetailAPIView.as_view()),
-    path('model/',                      ModelListAPIView.as_view()),
-    path('model/<str:id>/',             ModelDetailAPIView.as_view()),
+    # using re_path to make trailing slashs optional
+    re_path(r'validationrequest/?$',      ValidationRequestListAPIView.as_view()),
+    re_path(r'validationrequest/<str:id>/?$', ValidationRequestDetailAPIView.as_view()),
+    re_path(r'validationtask/?$',             ValidationTaskListAPIView.as_view()),
+    re_path(r'validationtask/<str:id>/?$',    ValidationTaskDetailAPIView.as_view()),
+    re_path(r'validationoutcome/?$',          ValidationOutcomeListAPIView.as_view()),
+    re_path(r'validationoutcome/<str:id>/?$', ValidationOutcomeDetailAPIView.as_view()),
+    re_path(r'model/?$',                      ModelListAPIView.as_view()),
+    re_path(r'model/<str:id>/?$',             ModelDetailAPIView.as_view()),
 
     # Django Admin charts
     path("chart/filter-options/", charts.get_filter_options),

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -156,7 +156,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '100/hour',
         'user': '1000/hour',
-        'submit_validation_request': '10/hour'
+        'submit_validation_request': '1000/hour' if DEVELOPMENT and DEBUG else '10/hour'
     }
 }
 

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -30,7 +30,7 @@ test.describe('API - ValidationRequest', () => {
         expect(response.status()).toBe(201);
     });
 
-    test('POST without a trailing slash accepts a valid file', async ({ request }) => {
+    test('POST without trailing slash accepts valid file', async ({ request }) => {
 
         // try to post a valid file
         const file_path = 'e2e/fixtures/valid_file.ifc';

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -30,6 +30,29 @@ test.describe('API - ValidationRequest', () => {
         expect(response.status()).toBe(201);
     });
 
+    test('POST without a trailing slash accepts a valid file', async ({ request }) => {
+
+        // try to post a valid file
+        const file_path = 'e2e/fixtures/valid_file.ifc';
+        const file_name = basename(file_path);
+        const file = new File([readFileSync(file_path)], file_name);
+        const form = new FormData();
+        form.append('file', file);
+        form.append('file_name', file_name);
+
+        let hash = btoa(TEST_CREDENTIALS);
+        const response = await request.post(`${BASE_URL}/api/validationrequest`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            },
+            multipart: form
+        });
+
+        // check if the response is correct - 201 Created
+        expect(response.statusText()).toBe('Created');
+        expect(response.status()).toBe(201);
+    });
+
     test('POST implements file size limit', async ({ request }) => {
 
         // try to post a large file
@@ -52,6 +75,76 @@ test.describe('API - ValidationRequest', () => {
         expect(response.statusText()).toBe('Request Entity Too Large');
         expect(response.status()).toBe(413); 
         expect(await response.json()).toEqual({ message: 'File size exceeds allowed file size limit (256 MB).' });
+    });
+
+    test('GET returns a list', async ({ request }) => {
+
+        // try to post a valid file
+        const file_path = 'e2e/fixtures/valid_file.ifc';
+        const file_name = basename(file_path);
+        const file = new File([readFileSync(file_path)], file_name);
+        const form = new FormData();
+        form.append('file', file);
+        form.append('file_name', file_name);
+
+        let hash = btoa(TEST_CREDENTIALS);
+        let response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            },
+            multipart: form
+        });
+
+        // retrieve list of ValidationRequests
+        response = await request.get(`${BASE_URL}/api/validationrequest`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            }
+        });
+
+        // check if the response is correct - 200 OK
+        expect(response.statusText()).toBe('OK');
+        expect(response.status()).toBe(200);
+        const data = await response.json();
+        expect(data).toBeInstanceOf(Array);
+        expect(data.length).toBeGreaterThan(0);
+        expect(data[0]).toHaveProperty('public_id');
+        expect(data[0]).toHaveProperty('file_name');
+    });
+
+    test('GET without trailing slash returns a list', async ({ request }) => {
+
+        // try to post a valid file
+        const file_path = 'e2e/fixtures/valid_file.ifc';
+        const file_name = basename(file_path);
+        const file = new File([readFileSync(file_path)], file_name);
+        const form = new FormData();
+        form.append('file', file);
+        form.append('file_name', file_name);
+
+        let hash = btoa(TEST_CREDENTIALS);
+        let response = await request.post(`${BASE_URL}/api/validationrequest`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            },
+            multipart: form
+        });
+
+        // retrieve list of ValidationRequests
+        response = await request.get(`${BASE_URL}/api/validationrequest`, {
+            headers: {
+                'Authorization': `Basic ${hash}`,
+            }
+        });
+
+        // check if the response is correct - 200 OK
+        expect(response.statusText()).toBe('OK');
+        expect(response.status()).toBe(200);
+        const data = await response.json();
+        expect(data).toBeInstanceOf(Array);
+        expect(data.length).toBeGreaterThan(0);
+        expect(data[0]).toHaveProperty('public_id');
+        expect(data[0]).toHaveProperty('file_name');
     });
 
 });


### PR DESCRIPTION
Protect against and tests for invalid scenarios:
- empty filename
- empty file (0 bytes)
- filename not ending with '.ifc'
- multiple files in one go
- invalid method (PUT instead of POST)