### PR TITLE
IVS-604 - Reject invalid API usage

### DIFF
--- a/backend/apps/ifc_validation/views.py
+++ b/backend/apps/ifc_validation/views.py
@@ -12,7 +12,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.exceptions import APIException
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.decorators import throttle_classes
@@ -33,7 +32,6 @@ logger = logging.getLogger(__name__)
 class ValidationRequestDetailAPIView(APIView):
 
     queryset = ValidationRequest.objects.all()
-    authentication_classes = [SessionAuthentication, TokenAuthentication, BasicAuthentication]
     permission_classes = [IsAuthenticated]
     parser_classes = (MultiPartParser, FormParser)
     serializer_class = ValidationRequestSerializer
@@ -78,7 +76,6 @@ class ValidationRequestDetailAPIView(APIView):
 class ValidationRequestListAPIView(APIView):
 
     queryset = ValidationRequest.objects.all()
-    authentication_classes = [SessionAuthentication, TokenAuthentication, BasicAuthentication]
     permission_classes = [IsAuthenticated]
     parser_classes = (MultiPartParser, FormParser)
     serializer_class = ValidationRequestSerializer
@@ -132,6 +129,11 @@ class ValidationRequestListAPIView(APIView):
                         if file_i is not None: files += file_i
                     logger.info(f"Received {len(files)} file(s) - files: {files}")
 
+                    # only accept one file (for now)
+                    if len(files) != 1:
+                        data = {'message': f"Only one file can be uploaded at a time."}
+                        return Response(data, status=status.HTTP_400_BAD_REQUEST)
+
                     # retrieve file size and save
                     uploaded_file = serializer.validated_data
                     logger.info(f'uploaded_file = {uploaded_file}')
@@ -140,6 +142,11 @@ class ValidationRequestListAPIView(APIView):
                     file_length = f.tell()
                     file_name = uploaded_file['file_name']
                     logger.info(f"file_length for uploaded file {file_name} = {file_length} ({file_length / (1024*1024)} MB)")
+
+                    # check if file name ends with .ifc
+                    if not file_name.lower().endswith('.ifc'):
+                        data = {'file_name': "File name must end with '.ifc'."}
+                        return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
                     # apply file size limit
                     if file_length > MAX_FILE_SIZE_IN_MB * 1024 * 1024:
@@ -172,7 +179,6 @@ class ValidationRequestListAPIView(APIView):
 class ValidationTaskDetailAPIView(APIView):
 
     queryset = ValidationTask.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ValidationTaskSerializer
     throttle_classes = [UserRateThrottle]
@@ -198,7 +204,6 @@ class ValidationTaskDetailAPIView(APIView):
 class ValidationTaskListAPIView(APIView):
 
     queryset = ValidationTask.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ValidationTaskSerializer
     throttle_classes = [UserRateThrottle]
@@ -229,7 +234,6 @@ class ValidationTaskListAPIView(APIView):
 class ValidationOutcomeDetailAPIView(APIView):
 
     queryset = ValidationOutcome.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ValidationOutcomeSerializer
     throttle_classes = [UserRateThrottle]
@@ -255,7 +259,6 @@ class ValidationOutcomeDetailAPIView(APIView):
 class ValidationOutcomeListAPIView(APIView):
 
     queryset = ValidationOutcome.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ValidationOutcomeSerializer
     throttle_classes = [UserRateThrottle]
@@ -290,7 +293,6 @@ class ValidationOutcomeListAPIView(APIView):
 class ModelDetailAPIView(APIView):
 
     queryset = Model.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ModelSerializer
     throttle_classes = [UserRateThrottle]
@@ -316,7 +318,6 @@ class ModelDetailAPIView(APIView):
 class ModelListAPIView(APIView):
 
     queryset = Model.objects.all()
-    authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = ModelSerializer
     throttle_classes = [UserRateThrottle]

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -142,11 +142,13 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.BasicAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES':(
+        # 'rest_framework.permissions.AllowAny',
         'rest_framework.permissions.IsAuthenticated',
+        # 'rest_framework.permissions.IsAdminUser',
     ),
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
@@ -156,7 +158,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'anon': '100/hour',
         'user': '1000/hour',
-        'submit_validation_request': '10/hour'
+        'submit_validation_request': '1000/hour' if DEVELOPMENT and DEBUG else '10/hour'
     }
 }
 

--- a/e2e/fixtures/invalid_file_extension
+++ b/e2e/fixtures/invalid_file_extension
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [ReferenceView_V1.2]', 'ExchangeRequirement [Any]'),'2;1');
+FILE_NAME('pass_header_policy.ifc','2025-02-13T15:58:45',('jdoe'),('Acme Inc.'),'ABC rel. 0.1.2','Acme Inc. - MyFabTool - 2025.1','IFC4 model');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPERSON($,$,'',$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/e2e/fixtures/valid_file2.ifc
+++ b/e2e/fixtures/valid_file2.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [ReferenceView_V1.2]', 'ExchangeRequirement [Any]'),'2;1');
+FILE_NAME('pass_header_policy.ifc','2025-02-13T15:58:45',('jdoe'),('Acme Inc.'),'ABC rel. 0.1.2','Acme Inc. - MyFabTool - 2025.1','IFC4 model');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPERSON($,$,'',$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -13,13 +13,28 @@ function createAuthHeader(credentials) {
     };
 }
 
-function createFormData(filePath) {
+function createFormData(filePath, fileName = undefined) {
 
-    const fileName = basename(filePath);
-    const file = new File([readFileSync(filePath)], fileName);
+    const name = fileName ?? basename(filePath);
+    const file = new File([readFileSync(filePath)], name);
     const form = new FormData();
     form.append('file', file);
-    form.append('file_name', fileName);
+    form.append('file_name', name);
+    return form;
+}
+
+function createFormDataForTwoFiles(filePath1, filePath2) {
+
+    const name1 = basename(filePath1);
+    const file1 = new File([readFileSync(filePath1)], name1);
+    const name2 = basename(filePath2);
+    const file2 = new File([readFileSync(filePath2)], name2);
+
+    const form = new FormData();
+    form.append('file', file1);
+    form.append('file_name', name1);
+    form.append('file', file2);
+    form.append('file_name', name2);
     return form;
 }
 
@@ -78,6 +93,80 @@ test.describe('API - ValidationRequest', () => {
         expect(await response.json()).toEqual({ message: 'File size exceeds allowed file size limit (256 MB).' });
     });
 
+    test('POST rejects empty file', async ({ request }) => {
+
+        // try to post an empty file
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: createAuthHeader(TEST_CREDENTIALS),
+            multipart: createFormData('e2e/fixtures/empty_file.ifc')
+        });
+
+        // check if the response is correct - 400 Bad Request
+        expect(response.statusText()).toBe('Bad Request');
+        expect(response.status()).toBe(400); 
+        expect(await response.json()).toEqual({ file: [ 'The submitted file is empty.' ] });
+    });
+
+    test('POST rejects empty file name', async ({ request }) => {
+
+        // try to post a file with empty filename
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: createAuthHeader(TEST_CREDENTIALS),
+            multipart: createFormData('e2e/fixtures/valid_file.ifc', '')
+        });
+
+        // check if the response is correct - 400 Bad Request
+        expect(response.statusText()).toBe('Bad Request');
+        expect(response.status()).toBe(400); 
+        expect(await response.json()).toStrictEqual({
+            "file": [ "The submitted data was not a file. Check the encoding type on the form." ], 
+            "file_name": [ "This field is required." ]
+        });
+    });
+
+    test('POST only accepts *.ifc files', async ({ request }) => {
+
+        // try to post a file with invalid file extension
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: createAuthHeader(TEST_CREDENTIALS),
+            multipart: createFormData('e2e/fixtures/invalid_file_extension')
+        });
+
+        // check if the response is correct - 400 Bad Request
+        expect(response.statusText()).toBe('Bad Request');
+        expect(response.status()).toBe(400); 
+        expect(await response.json()).toEqual({ file_name: "File name must end with '.ifc'." });
+    });
+
+    test('POST only accepts a single file (for now)', async ({ request }) => {
+
+        // try to post two valid files
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: createAuthHeader(TEST_CREDENTIALS),
+            multipart: createFormDataForTwoFiles(
+                'e2e/fixtures/valid_file.ifc', 
+                'e2e/fixtures/valid_file2.ifc'
+            )
+        });
+
+        // check if the response is correct - 400 Bad Request
+        expect(response.statusText()).toBe('Bad Request');
+        expect(response.status()).toBe(400); 
+        expect(await response.json()).toEqual({ message: 'Only one file can be uploaded at a time.' });
+    });
+
+    test('POST without authorization header returns 401', async ({ request }) => {
+
+        // try to post a valid file but without authorization header
+        const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+        });
+
+        // check if the response is correct - 401 Unauthorized
+        expect(response.statusText()).toBe('Unauthorized');
+        expect(response.status()).toBe(401);
+    });
+
     test('GET returns a list', async ({ request }) => {
 
         // post a valid file
@@ -126,6 +215,16 @@ test.describe('API - ValidationRequest', () => {
         expect(data.length).toBeGreaterThan(0);
         expect(data[0]).toHaveProperty('public_id');
         expect(data[0]).toHaveProperty('file_name');
+    });
+
+    test('GET without authorization header returns 401', async ({ request }) => {
+
+        // retrieve list of ValidationRequests
+        const response = await request.get(`${BASE_URL}/api/validationrequest/`);
+
+        // check if the response is correct - 401 Unauthorized
+        expect(response.statusText()).toBe('Unauthorized');
+        expect(response.status()).toBe(401);
     });
 
 });

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { basename } from 'path';
+import { statSync } from 'fs';
 
 const BASE_URL = 'http://localhost:8000';
 const TEST_CREDENTIALS = 'root:root';
@@ -13,10 +14,20 @@ function createAuthHeader(credentials) {
     };
 }
 
+function findAndReadFileSync(filepath) {
+    
+    if (statSync(filepath, { throwIfNoEntry: false })?.isFile()) {
+        return readFileSync(filepath);        
+    } else if (statSync('e2e/' + filepath, { throwIfNoEntry: false })?.isFile()) {
+        return readFileSync('e2e/' + filepath);
+    }
+    throw new Error(`File does not exist: ${filepath}`);
+}
+
 function createFormData(filePath, fileName = undefined) {
 
     const name = fileName ?? basename(filePath);
-    const file = new File([readFileSync(filePath)], name);
+    const file = new File([findAndReadFileSync(filePath)], name);
     const form = new FormData();
     form.append('file', file);
     form.append('file_name', name);
@@ -26,9 +37,9 @@ function createFormData(filePath, fileName = undefined) {
 function createFormDataForTwoFiles(filePath1, filePath2) {
 
     const name1 = basename(filePath1);
-    const file1 = new File([readFileSync(filePath1)], name1);
+    const file1 = new File([findAndReadFileSync(filePath1)], name1);
     const name2 = basename(filePath2);
-    const file2 = new File([readFileSync(filePath2)], name2);
+    const file2 = new File([findAndReadFileSync(filePath2)], name2);
 
     const form = new FormData();
     form.append('file', file1);
@@ -56,7 +67,7 @@ test.describe('API - ValidationRequest', () => {
         // try to post a valid file
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+            multipart: createFormData('fixtures/valid_file.ifc')
         });
 
         // check if the response is correct - 201 Created
@@ -69,7 +80,7 @@ test.describe('API - ValidationRequest', () => {
         // try to post a valid file
         const response = await request.post(`${BASE_URL}/api/validationrequest`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+            multipart: createFormData('fixtures/valid_file.ifc')
         });
 
         // check if the response is correct - 201 Created
@@ -98,7 +109,7 @@ test.describe('API - ValidationRequest', () => {
         // try to post an empty file
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/empty_file.ifc')
+            multipart: createFormData('fixtures/empty_file.ifc')
         });
 
         // check if the response is correct - 400 Bad Request
@@ -112,7 +123,7 @@ test.describe('API - ValidationRequest', () => {
         // try to post a file with empty filename
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/valid_file.ifc', '')
+            multipart: createFormData('fixtures/valid_file.ifc', '')
         });
 
         // check if the response is correct - 400 Bad Request
@@ -129,7 +140,7 @@ test.describe('API - ValidationRequest', () => {
         // try to post a file with invalid file extension
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/invalid_file_extension')
+            multipart: createFormData('fixtures/invalid_file_extension')
         });
 
         // check if the response is correct - 400 Bad Request
@@ -144,8 +155,8 @@ test.describe('API - ValidationRequest', () => {
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
             multipart: createFormDataForTwoFiles(
-                'e2e/fixtures/valid_file.ifc', 
-                'e2e/fixtures/valid_file2.ifc'
+                'fixtures/valid_file.ifc', 
+                'fixtures/valid_file2.ifc'
             )
         });
 
@@ -159,7 +170,7 @@ test.describe('API - ValidationRequest', () => {
 
         // try to post a valid file but without authorization header
         const response = await request.post(`${BASE_URL}/api/validationrequest/`, {
-            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+            multipart: createFormData('fixtures/valid_file.ifc')
         });
 
         // check if the response is correct - 401 Unauthorized
@@ -172,7 +183,7 @@ test.describe('API - ValidationRequest', () => {
         // post a valid file
         let response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+            multipart: createFormData('fixtures/valid_file.ifc')
         });
 
         // retrieve list of ValidationRequests
@@ -197,7 +208,7 @@ test.describe('API - ValidationRequest', () => {
         // post a valid file
         let response = await request.post(`${BASE_URL}/api/validationrequest/`, {
             headers: createAuthHeader(TEST_CREDENTIALS),
-            multipart: createFormData('e2e/fixtures/valid_file.ifc')
+            multipart: createFormData('fixtures/valid_file.ifc')
         });
 
         // retrieve list of ValidationRequests


### PR DESCRIPTION
Protects against and tests for common invalid scenarios:
- empty filename
- empty file (0 bytes)
- filename not ending with `'.ifc'`
- multiple files in one request
- missing authorization header