### PR TITLE
IVS-623 - Redirect browsers hitting /api to Swagger UI

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -164,7 +164,11 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'IFC Validation Service API (PREVIEW)',
-    'DESCRIPTION': 'API for the buildingSMART Validation Service',
+    'DESCRIPTION': (
+        'API for the buildingSMART Validation Service.\n\n'
+        '[API Quickstart Documentation]'
+        '(https://github.com/buildingSMART/validate/blob/docs/gh-pages/docs/dev/api_quickstart.md)'
+    ),
     'VERSION': os.environ.get("VERSION", "UNDEFINED"),
     'SERVE_INCLUDE_SCHEMA': False,
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,9 +1,11 @@
 import re
 from django.contrib import admin
+from django.http import HttpResponseRedirect
 from django.urls import include, path, re_path
 from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.static import serve
+from django.views import View
 
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
@@ -11,11 +13,27 @@ from .views_auth import login, logout, callback, whoami
 
 from core.settings import MEDIA_ROOT, MEDIA_URL, STATIC_URL, STATIC_ROOT, DEVELOPMENT
 
+class APIRedirectView(View):
+    """
+    Redirect browser requests to Swagger UI, API clients to continue normally
+    """
+    def get(self, request, *args, **kwargs):
+        
+        # for browsers, redirect to Swagger UI
+        accept_header = request.META.get('HTTP_ACCEPT', '') 
+        if 'text/html' in accept_header: # is request from a browser?
+            return HttpResponseRedirect('/api/swagger-ui/')
+        
+        # for API clients, redirect to schema
+        return HttpResponseRedirect('/api/schema/')
 
 urlpatterns = [
 
     # Django Admin
     path("admin/",           admin.site.urls),
+
+    # API redirect for browsers
+    path('api/',             APIRedirectView.as_view(), name='api-redirect'),
 
     # API info + documentation
     path('api/schema/',      SpectacularAPIView.as_view(), name='schema'),

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -318,7 +318,7 @@ test.describe('API - ValidationRequest', () => {
     });
 });
 
-test.describe('API - Browsers', () => {
+test.describe('API - Browsers vs Clients', () => {
 
     test('Browsers will be redirected to /api/swagger-ui', async ({ request }) => {
 
@@ -351,5 +351,31 @@ test.describe('API - Browsers', () => {
         expect(response.status()).toBe(200);
         expect(response.url()).toBe(`${BASE_URL}/api/swagger-ui/`);
     });
+
+    test('API clients will be redirected to /api/schema', async ({ request }) => {
+
+        // root of /api
+        const response = await request.get(`${BASE_URL}/api/`, {
+            maxRedirects: 0
+        });
+
+        // check if the response is correct - 302 Found
+        expect(response.statusText()).toBe('Found');
+        expect(response.status()).toBe(302);
+        expect(response.headers()['location']).toBe('/api/schema/');
+    });
+
+    test('API clients are redirected to /api/schema', async ({ request }) => {
+
+        // root of /api
+        const response = await request.get(`${BASE_URL}/api/`, {
+            maxRedirects: 5
+        });
+
+        // check if the response is correct - 200 OK
+        expect(response.statusText()).toBe('OK');
+        expect(response.status()).toBe(200);
+        expect(response.url()).toBe(`${BASE_URL}/api/schema/`);
+    });  
 
 });

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -316,5 +316,40 @@ test.describe('API - ValidationRequest', () => {
         expect(response.statusText()).toBe('Unauthorized');
         expect(response.status()).toBe(401);
     });
+});
+
+test.describe('API - Browsers', () => {
+
+    test('Browsers will be redirected to /api/swagger-ui', async ({ request }) => {
+
+        // root of /api
+        const response = await request.get(`${BASE_URL}/api/`, {
+            headers: {
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8'
+            },
+            maxRedirects: 0
+        });
+
+        // check if the response is correct - 302 Found
+        expect(response.statusText()).toBe('Found');
+        expect(response.status()).toBe(302);
+        expect(response.headers()['location']).toBe('/api/swagger-ui/');
+    });
+
+    test('Browsers are redirected to /api/swagger-ui', async ({ request }) => {
+
+        // root of /api
+        const response = await request.get(`${BASE_URL}/api/`, {
+            headers: {
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8'
+            },
+            maxRedirects: 5
+        });
+
+        // check if the response is correct - 200 OK
+        expect(response.statusText()).toBe('OK');
+        expect(response.status()).toBe(200);
+        expect(response.url()).toBe(`${BASE_URL}/api/swagger-ui/`);
+    });
 
 });


### PR DESCRIPTION
- redirect /api to /api/swagger-ui (browsers)
- redirect /api to /api/schema (non-browsers)
- link to API quick-start documentation
- e2e tests