### PR TITLE
IVS-630 - Minor Django Admin improvements

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -56,6 +56,9 @@ urlpatterns = [
 
 if DEVELOPMENT:
     urlpatterns += [
+        # redirect root to admin
+        path("", lambda request: HttpResponseRedirect("/admin/")),
+        # load debug toolbar
         path("__debug__/", include("debug_toolbar.urls")),
     ]
 


### PR DESCRIPTION
Mainly for convenience, navigating around

- Make user clickable (`ValidationRequest`)
- Make requests clickable (`AuthoringTool`)
- Make requests clickable (`User`)
- Redirect root to /admin in `DEVELOPMENT`