### PR TITLE
check subprocess returncode

### DIFF
--- a/backend/apps/ifc_validation/tasks/check_programs.py
+++ b/backend/apps/ifc_validation/tasks/check_programs.py
@@ -186,7 +186,8 @@ def run_subprocess(
             stderr=subprocess.PIPE,
             text=True,
             timeout=TASK_TIMEOUT_LIMIT,
-            env= os.environ.copy()
+            env= os.environ.copy(),
+            check=True
         )
         logger.info(f'test run task task name {task.type}, task value : {task}')
         return proc
@@ -194,4 +195,4 @@ def run_subprocess(
     except Exception as err:
         logger.exception(f"{type(err).__name__} in task {task.id} : {task.type}")
         task.mark_as_failed(err)
-        raise type(err)(f"Unknown error during validation task {task.id}: {task.type}") from err
+        raise RuntimeError(f"Unknown error during validation task {task.id}: {task.type}") from err


### PR DESCRIPTION
We don't check that the subprocess actually succeeds (returns 0 exit code)

Propagating the typed exception (I think that was my hack) doesn't work because of the CalledProcessError constructor.

```
Traceback (most recent call last):
  File "/mnt/c/Users/tkrij/Documents/AECgeeks/projects/buildingsmart/validate/backend/apps/ifc_validation/tasks/task_runner.py", line 130, in validation_subtask_runner
    context = config.check_program(TaskContext(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/Users/tkrij/Documents/AECgeeks/projects/buildingsmart/validate/backend/apps/ifc_validation/tasks/check_programs.py", line 48, in check_schema       
    proc = run_subprocess(
           ^^^^^^^^^^^^^^^
  File "/mnt/c/Users/tkrij/Documents/AECgeeks/projects/buildingsmart/validate/backend/apps/ifc_validation/tasks/check_programs.py", line 225, in run_subprocess    
    raise type(err)(f"Unknown error during validation task {task.id}: {task.type}") from err
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CalledProcessError.__init__() missing 1 required positional argument: 'cmd'
```