### PR TITLE
IVS-641 - Hide internal db identifier fields

### DIFF
--- a/backend/apps/ifc_validation/serializers.py
+++ b/backend/apps/ifc_validation/serializers.py
@@ -29,8 +29,8 @@ class ValidationRequestSerializer(BaseSerializer):
         model = ValidationRequest
         fields = '__all__'
         show = ["public_id", "model_public_id"]
-        hide = ["id", "model"]
-        read_only_fields = ['size', 'created_by']
+        hide = ["id", "model", "deleted", "created_by", "updated_by"]
+        read_only_fields = ['size', 'created_by', 'updated_by']
 
 
 class ValidationTaskSerializer(BaseSerializer):

--- a/backend/apps/ifc_validation/serializers.py
+++ b/backend/apps/ifc_validation/serializers.py
@@ -29,7 +29,7 @@ class ValidationRequestSerializer(BaseSerializer):
         model = ValidationRequest
         fields = '__all__'
         show = ["public_id", "model_public_id"]
-        hide = ["id"]
+        hide = ["id", "model"]
         read_only_fields = ['size', 'created_by']
 
 

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -310,7 +310,7 @@ test.describe('API - ValidationRequest', () => {
         expect(response.status()).toBe(401);
     });
 
-    test('GET should not return internal identifiers', async ({ request }) => {
+    test('GET should not return internal identifiers and fields', async ({ request }) => {
 
         // post a valid file
         let response = await request.post(`${BASE_URL}/api/validationrequest/`, {
@@ -336,6 +336,9 @@ test.describe('API - ValidationRequest', () => {
         expect(data).not.toHaveProperty('model');
         expect(data).not.toHaveProperty('model_id');
         expect(data).not.toHaveProperty('id');
+        expect(data).not.toHaveProperty('deleted');
+        expect(data).not.toHaveProperty('created_by');
+        expect(data).not.toHaveProperty('updated_by');
     });
 
     test('pagination: offset window has no overlap with first page', async ({ request }) => {

--- a/e2e/tests/validate_api.test.js
+++ b/e2e/tests/validate_api.test.js
@@ -310,6 +310,34 @@ test.describe('API - ValidationRequest', () => {
         expect(response.status()).toBe(401);
     });
 
+    test('GET should not return internal identifiers', async ({ request }) => {
+
+        // post a valid file
+        let response = await request.post(`${BASE_URL}/api/validationrequest/`, {
+            headers: createAuthHeader(TEST_CREDENTIALS),
+            multipart: createFormData('fixtures/valid_file.ifc')
+        });
+        const json_body = await response.json();
+        const public_id = json_body['public_id'];
+
+        // retrieve a single instance
+        response = await request.get(`${BASE_URL}/api/validationrequest/${public_id}`, {
+            headers: createAuthHeader(TEST_CREDENTIALS)
+        });
+
+        // check if the response is correct - 200 OK
+        expect(response.statusText()).toBe('OK');
+        expect(response.status()).toBe(200);
+
+        // check if the json body is correct
+        const data = await response.json();
+        expect(data).toBeInstanceOf(Object);
+        expect(data).toHaveProperty('public_id');
+        expect(data).not.toHaveProperty('model');
+        expect(data).not.toHaveProperty('model_id');
+        expect(data).not.toHaveProperty('id');
+    });
+
     test('pagination: offset window has no overlap with first page', async ({ request }) => {
         const first = await request.get(`${BASE_URL}/api/validationrequest/`, {
           headers: createAuthHeader(TEST_CREDENTIALS)


### PR DESCRIPTION
Hide `model_id` and other fields in `ValidationRequest` JSON + e2e test