### PR TITLE
IVS-112 record status of failed tasks

### DIFF
--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -160,7 +160,7 @@ def status_combine(*args, allow_not_executed=False):
     return statuses[max(map(statuses.index, args))]
 
 
-def format_request(request):
+def format_request(request : ValidationRequest):
     return {
         "id": request.public_id,
         "code": request.public_id,


### PR DESCRIPTION
Maybe not the cleanest but gets the job done.

Tested with:

```diff
diff --git a/backend/apps/ifc_validation/checks/check_gherkin.py b/backend/apps/ifc_validation/checks/check_gherkin.py
index 16d3131..71ccdad 100644
--- a/backend/apps/ifc_validation/checks/check_gherkin.py
+++ b/backend/apps/ifc_validation/checks/check_gherkin.py
@@ -8,6 +8,7 @@ except:
     import apps.ifc_validation.checks.ifc_gherkin_rules as gherkin_rules  # tests

 def perform(ifc_fn, task_id, rule_type, verbose, purepythonparser=False):
+    raise NotImplementedError("asdasd")

     try:
```

<img width="1377" height="164" alt="afbeelding" src="https://github.com/user-attachments/assets/b55277a1-2dfd-4855-bcf4-70e196478c4a" />

<img width="822" height="346" alt="afbeelding" src="https://github.com/user-attachments/assets/54094d94-3335-4e2a-9069-4767414990cc" />
