### PR TITLE
IVS-512 - Improve Report Performance

### DIFF
--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -564,7 +564,12 @@ def report(request, id: str):
             key = 'Schema - Version' if label == 'prerequisites' else feature
             grouped_gherkin_outcomes_counts[label][key] = count
 
-            all_feature_outcomes : typing.Sequence[ValidationOutcome] = itertools.chain.from_iterable(t.outcomes.filter(feature=feature)[:MAX_OUTCOMES_PER_RULE].iterator() for t in tasks)
+            all_feature_outcomes : typing.Sequence[ValidationOutcome] = itertools.chain.from_iterable(
+                t.outcomes.filter(feature=feature)
+                 .prefetch_related("instance")                 
+                 [:MAX_OUTCOMES_PER_RULE]
+                 .iterator(chunk_size=100) for t in tasks)
+                 
             for outcome in all_feature_outcomes:
 
                 mapped = {


### PR DESCRIPTION
Changed implementation; aggregate per feature first

Example improvements:
```
...
2025-11-14 20:12:26,777 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin old mapping took: 0:00:08.181015
2025-11-14 20:12:26,777 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin new mapping took: 0:00:02.067953
2025-11-14 20:12:26,856 [INFO] m:basehttp pid:79619 tid:6306492416 -- "GET /bff/api/report/r268704015?type=normative HTTP/1.1" 200 58363
...
2025-11-14 20:12:37,091 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin old mapping took: 0:00:08.209100
2025-11-14 20:12:37,091 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin new mapping took: 0:00:01.965674
2025-11-14 20:12:37,097 [INFO] m:basehttp pid:79619 tid:6306492416 -- "GET /bff/api/report/r268704015?type=normative HTTP/1.1" 200 58363
...
2025-11-14 20:12:58,176 [INFO] m:views_legacy pid:79619 tid:6289666048 -- Gherkin old mapping took: 0:00:43.327449
2025-11-14 20:12:58,176 [INFO] m:views_legacy pid:79619 tid:6289666048 -- Gherkin new mapping took: 0:00:03.412818
2025-11-14 20:12:58,202 [INFO] m:basehttp pid:79619 tid:6289666048 -- "GET /bff/api/report/r419044088?type=normative HTTP/1.1" 200 94013
...
2025-11-14 20:13:01,975 [INFO] m:views_legacy pid:79619 tid:13304360960 -- Gherkin old mapping took: 0:00:49.108304
2025-11-14 20:13:01,975 [INFO] m:views_legacy pid:79619 tid:13304360960 -- Gherkin new mapping took: 0:00:02.754449
2025-11-14 20:13:01,981 [INFO] m:basehttp pid:79619 tid:13304360960 -- "GET /bff/api/report/r802490779?type=normative HTTP/1.1" 200 72524
...
2025-11-14 20:13:12,050 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin old mapping took: 0:00:26.268733
2025-11-14 20:13:12,050 [INFO] m:views_legacy pid:79619 tid:6306492416 -- Gherkin new mapping took: 0:00:02.172313
2025-11-14 20:13:12,062 [INFO] m:basehttp pid:79619 tid:6306492416 -- "GET /bff/api/report/r802490779?type=normative HTTP/1.1" 200 72524
```