### PR TITLE
Update Dz.js

### DIFF
--- a/frontend/src/Dz.js
+++ b/frontend/src/Dz.js
@@ -37,7 +37,7 @@ function Dz() {
             acceptedFiles: ".ifc",
             parallelUploads: 100,
             maxFiles: 100,
-            maxFileSize: MAX_FILE_SIZE_IN_MB,
+            maxFilesize: MAX_FILE_SIZE_IN_MB,
             autoProcessQueue: false,
             addRemoveLinks: true,
             withCredentials: true,


### PR DESCRIPTION
fix typo in argument declaration.
renaming argument maxFileSize to maxFilesize for Dropzone component according to documentation https://docs.dropzone.dev/configuration/basics/configuration-options.

Since Dropzone.maxFilesize default limit is 256 MB, the bug may have been transparent but modifying the value of the variable MAX_FILE_SIZE_IN_MB shows it is not taken into account.