### PR TITLE
IVS-846 - fix premature 'valid' in combined section status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,4 @@ jobs:
           MEDIA_ROOT=./apps/ifc_validation/fixtures python3 manage.py test apps.ifc_validation.tests.tests_header_syntax_validation_task --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3
           MEDIA_ROOT=./apps/ifc_validation/fixtures python3 manage.py test apps.ifc_validation.tests.tests_syntax_validation_task --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3
           MEDIA_ROOT=./apps/ifc_validation/fixtures python3 manage.py test apps.ifc_validation.tests.tests_schema_validation_task --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3
+          MEDIA_ROOT=./apps/ifc_validation/fixtures python3 manage.py test apps.ifc_validation.tests.tests_status_combine --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -66,7 +66,7 @@ stop-worker:
 	-$(PYTHON) -m celery -A core control shutdown \
 	    --destination=worker@$(shell hostname) || true
 
-test: test-models test-header-validation-task test-syntax-task test-syntax-header-validation-task test-schema-task test-magic-and-av-task test-utils test-file-retention-task
+test: test-models test-header-validation-task test-syntax-task test-syntax-header-validation-task test-schema-task test-magic-and-av-task test-utils test-file-retention-task test-status-combine
 
 test-models:
 	MEDIA_ROOT=./apps/ifc_validation/fixtures $(PYTHON) manage.py test apps/ifc_validation_models --settings apps.ifc_validation_models.test_settings --debug-mode --verbosity 3
@@ -88,6 +88,9 @@ test-magic-and-av-task:
 
 test-file-retention-task:
 	MEDIA_ROOT=./apps/ifc_validation/fixtures $(PYTHON) manage.py test apps.ifc_validation.tests.tests_file_retention_task --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3
+
+test-status-combine:
+	MEDIA_ROOT=./apps/ifc_validation/fixtures $(PYTHON) manage.py test apps.ifc_validation.tests.tests_status_combine --settings apps.ifc_validation.test_settings --debug-mode --verbosity 3
 
 test-utils:
 	$(PYTHON) manage.py test core.tests.test_utils --debug-mode --verbosity 3

--- a/backend/apps/ifc_validation/tests/tests_status_combine.py
+++ b/backend/apps/ifc_validation/tests/tests_status_combine.py
@@ -1,0 +1,31 @@
+from django.test import SimpleTestCase
+
+from apps.ifc_validation_bff.status import status_combine
+
+
+class StatusCombineTests(SimpleTestCase):
+
+    def test_both_valid_returns_valid(self):
+        self.assertEqual(status_combine('v', 'v'), 'v')
+
+    def test_pending_and_valid_returns_pending(self):
+        # Regression: previously returned 'v', causing a green flash in the UI
+        # while a slower sibling task was still running.
+        self.assertEqual(status_combine('p', 'v'), 'p')
+
+    def test_pending_and_invalid_returns_invalid(self):
+        # A known failure surfaces immediately even if a sibling is still pending
+        # (e.g. a skipped task that will never write its status field).
+        self.assertEqual(status_combine('p', 'i'), 'i')
+
+    def test_valid_and_invalid_returns_invalid(self):
+        self.assertEqual(status_combine('v', 'i'), 'i')
+
+    def test_both_pending_returns_pending(self):
+        self.assertEqual(status_combine('p', 'p'), 'p')
+
+    def test_allow_not_executed_filters_n_when_mixed(self):
+        self.assertEqual(status_combine('n', 'v', allow_not_executed=True), 'v')
+
+    def test_allow_not_executed_keeps_n_when_all_n(self):
+        self.assertEqual(status_combine('n', 'n', allow_not_executed=True), 'n')

--- a/backend/apps/ifc_validation_bff/status.py
+++ b/backend/apps/ifc_validation_bff/status.py
@@ -1,0 +1,17 @@
+def status_combine(*args, allow_not_executed=False):
+    # status_header_syntax was introduced later and default initialized to `n`,
+    # which has higher severity order in this logic than valid (`v`), we don't
+    # want it to override the status for pre-existing data that never executed
+    # this check.
+    if allow_not_executed and not set(args) == {'n'}:
+        args = [a for a in args if a != 'n']
+
+    # Early return: 'p' (index 1) loses to 'v' (index 2) in max() below, so pending
+    # must be pulled out of the ranking — otherwise a fast sibling flashes green.
+    # But if a sibling already failed, surface the failure immediately (e.g. when
+    # a skipped task leaves its status field as None → 'p' permanently).
+    if 'p' in args and 'i' not in args:
+        return 'p'
+
+    statuses = "-pvnwi"
+    return statuses[max(map(statuses.index, args))]

--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -138,16 +138,7 @@ def get_feature_description(feature_code):
     return None
 
 
-def status_combine(*args, allow_not_executed=False):
-    # status_header_syntax was introduced later and default initialized to `n`,
-    # which has higher severity order in this logic than valid (`v`), we don't
-    # want it to override the status for pre-existing data that never executed
-    # this check.
-    if allow_not_executed and not set(args) == {'n'}:
-        args = [a for a in args if a != 'n']
-
-    statuses = "-pvnwi"
-    return statuses[max(map(statuses.index, args))]
+from apps.ifc_validation_bff.status import status_combine
 
 
 def format_request(request : ValidationRequest):


### PR DESCRIPTION
The status icon in the UI from a single task updates when individual subtasks are finished. For example, for schema we check IFC101 and ifcopenshell.validate. In case IFC101 is passing but ifcopenshell.validate fails, it briefly shows a green icon that turns red again. The same is true for IA & IP. 