### PR TITLE
IVS-820 - Pending Hourglass error

### DIFF
--- a/backend/apps/ifc_validation/tests/tests_premature_green.py
+++ b/backend/apps/ifc_validation/tests/tests_premature_green.py
@@ -142,3 +142,102 @@ class NoPrematureGreenTestCase(TestCase):
         m.status_syntax = St.NOT_VALIDATED
         m.save()
         self.assertEqual(ui_syntax(m, completed=True), St.NOT_VALIDATED)
+
+
+# ---- gate-aware replicas of the FIXED BFF cells (views_legacy.py _pending_n_to_p) ----
+# A not-yet-run check resolves to 'n' once the Model exists; while the request is NOT in a
+# terminal state it must show the pending hourglass ('p'), not grey. Gate on request.status,
+# NOT progress (progress hits 100 one task before status==COMPLETED — the t3' window).
+VR = ValidationRequest.Status
+_TERMINAL = (VR.COMPLETED, VR.FAILED)
+
+
+def _gate(status, req_status):
+    return 'p' if (status == St.NOT_VALIDATED and req_status not in _TERMINAL) else status
+
+
+def ui_schema_cell(m, req_status):   # gate AFTER combine, so a real 'i'/'w' is never hidden
+    return _gate(ui_schema(m), req_status)
+
+
+def ui_rules_cell(m, req_status):
+    return _gate(ui_rules(m), req_status)
+
+
+def ui_header_cell(m, req_status):
+    return _gate("p" if m.status_header is None else m.status_header, req_status)
+
+
+class PendingNotValidatedGateTestCase(NoPrematureGreenTestCase):
+    """IVS-820 follow-up: a not-yet-run check must show the pending hourglass ('p'),
+    not grey 'n', until the *request* reaches a terminal state (COMPLETED/FAILED).
+    Gates on request.status, NOT progress, because progress hits 100 one task before
+    status flips to COMPLETED (the t3' window)."""
+
+    # ----- SCHEMA cell -----
+    def test_schema_inprogress_notrun_shows_hourglass(self):
+        m = self._model()
+        m.status_prereq = St.VALID; m.save()
+        self._task(T.SCHEMA, [])
+        self.assertEqual(ui_schema_cell(self._fresh(m), VR.INITIATED), 'p')
+
+    def test_schema_t3prime_progress100_status_initiated_shows_hourglass(self):
+        # t3': progress==100 but status still INITIATED -> must NOT flash grey
+        m = self._model()
+        m.status_prereq = St.VALID; m.save()
+        self._task(T.SCHEMA, [])
+        self.req.progress = 100; self.req.status = VR.INITIATED; self.req.save()
+        self.assertEqual(ui_schema_cell(self._fresh(m), VR.INITIATED), 'p')
+
+    def test_schema_completed_skipped_stays_not_validated(self):
+        m = self._model()
+        m.status_prereq = St.VALID; m.save()
+        self._task(T.SCHEMA, [])
+        self.assertEqual(ui_schema_cell(self._fresh(m), VR.COMPLETED), St.NOT_VALIDATED)
+
+    def test_schema_completed_passed_is_green(self):
+        m = self._model()
+        m.status_prereq = St.VALID; m.save()
+        self._task(T.SCHEMA, [S.PASSED])
+        self.assertEqual(ui_schema_cell(self._fresh(m), VR.COMPLETED), St.VALID)
+
+    def test_schema_invalid_is_red_even_inprogress(self):
+        m = self._model()
+        m.status_prereq = St.VALID; m.save()
+        self._task(T.SCHEMA, [S.PASSED, S.ERROR])
+        self.assertEqual(ui_schema_cell(self._fresh(m), VR.INITIATED), St.INVALID)
+
+    # ----- RULES cell: the warning-hiding regression guard -----
+    def test_rules_inprogress_one_pending_shows_hourglass(self):
+        m = self._model()
+        self._task(T.NORMATIVE_IA, [S.PASSED])
+        self._task(T.NORMATIVE_IP, [])
+        self.assertEqual(ui_rules_cell(self._fresh(m), VR.INITIATED), 'p')
+
+    def test_rules_warning_sibling_not_hidden_by_gate(self):
+        # IA WARNING done, IP not run, mid-run: warning must STILL show ('w'), not be
+        # swallowed into 'p'. This is why the gate is applied AFTER status_combine.
+        m = self._model()
+        self._task(T.NORMATIVE_IA, [S.PASSED, S.WARNING])
+        self._task(T.NORMATIVE_IP, [])
+        self.assertEqual(ui_rules_cell(self._fresh(m), VR.INITIATED), St.WARNING)
+
+    def test_rules_completed_both_skipped_stays_not_validated(self):
+        m = self._model()
+        self._task(T.NORMATIVE_IA, [])
+        self._task(T.NORMATIVE_IP, [])
+        self.assertEqual(ui_rules_cell(self._fresh(m), VR.COMPLETED), St.NOT_VALIDATED)
+
+    # ----- single-task raw cell (header) -----
+    def test_header_inprogress_default_shows_hourglass(self):
+        m = self._model()
+        self.assertEqual(ui_header_cell(self._fresh(m), VR.INITIATED), 'p')
+
+    def test_header_completed_default_stays_not_validated(self):
+        m = self._model()
+        self.assertEqual(ui_header_cell(self._fresh(m), VR.COMPLETED), St.NOT_VALIDATED)
+
+    def test_header_failed_run_not_eternal_hourglass(self):
+        # FAILED is terminal -> not-run cells settle to grey, never stuck on hourglass
+        m = self._model()
+        self.assertEqual(ui_header_cell(self._fresh(m), VR.FAILED), St.NOT_VALIDATED)

--- a/backend/apps/ifc_validation_bff/views_legacy.py
+++ b/backend/apps/ifc_validation_bff/views_legacy.py
@@ -145,6 +145,21 @@ def get_feature_description(feature_code):
 from apps.ifc_validation_bff.status import status_combine
 
 
+# IVS-820 follow-up: a not-yet-run check resolves to 'n' (NOT_VALIDATED) once the Model row
+# exists, which the UI draws as grey "not validated". While the run hasn't reached a terminal
+# state, a not-run cell should still show the pending hourglass ('p'), not grey. Gate on
+# request.status, NOT progress: progress hits 100 one task BEFORE status flips to COMPLETED
+# (the t3' window), so a progress gate flashes grey prematurely. Apply AFTER status_combine for
+# the combined cells, so a real 'i'/'w' from a sibling is never hidden by the 'p' early-return.
+_TERMINAL_STATUS = (ValidationRequest.Status.COMPLETED, ValidationRequest.Status.FAILED)
+
+
+def _pending_n_to_p(status, request):
+    if status == "n" and request.status not in _TERMINAL_STATUS:
+        return "p"
+    return status
+
+
 def format_request(request : ValidationRequest):
     return {
         "id": request.public_id,
@@ -171,21 +186,21 @@ def format_request(request : ValidationRequest):
             # syntax, so stripping the pending syntax 'n' would flash green before red.
             allow_not_executed=(request.status == ValidationRequest.Status.COMPLETED)
         ),
-        "status_schema": status_combine(
+        "status_schema": _pending_n_to_p(status_combine(
             "p" if (request.model is None or request.model.status_schema_calculated is None) else request.model.status_schema_calculated,
             "p" if (request.model is None or request.model.status_prereq is None) else request.model.status_prereq
-        ),
-        "status_bsdd": "p" if (request.model is None or request.model.status_bsdd is None) else request.model.status_bsdd,
+        ), request),
+        "status_bsdd": _pending_n_to_p("p" if (request.model is None or request.model.status_bsdd is None) else request.model.status_bsdd, request),
         "status_mvd": "p" if (request.model is None or request.model.status_mvd is None) else request.model.status_mvd,
         "status_ids": "p" if (request.model is None or request.model.status_ids is None) else request.model.status_ids,
-        "status_header": "p" if (request.model is None or request.model.status_header is None) else request.model.status_header,
-        "status_rules": status_combine(
+        "status_header": _pending_n_to_p("p" if (request.model is None or request.model.status_header is None) else request.model.status_header, request),
+        "status_rules": _pending_n_to_p(status_combine(
             "p" if (request.model is None or request.model.status_ia_calculated is None) else request.model.status_ia_calculated,
             "p" if (request.model is None or request.model.status_ip_calculated is None)  else request.model.status_ip_calculated
-        ),
-        "status_ind": "p" if (request.model is None or request.model.status_industry_practices is None) else request.model.status_industry_practices,
-        "status_signatures": "p" if (request.model is None or request.model.status_signatures is None) else request.model.status_signatures,
-        "status_magic_clamav": "p" if (request.model is None or request.model.status_magic_clamav is None) else request.model.status_magic_clamav,
+        ), request),
+        "status_ind": _pending_n_to_p("p" if (request.model is None or request.model.status_industry_practices is None) else request.model.status_industry_practices, request),
+        "status_signatures": _pending_n_to_p("p" if (request.model is None or request.model.status_signatures is None) else request.model.status_signatures, request),
+        "status_magic_clamav": _pending_n_to_p("p" if (request.model is None or request.model.status_magic_clamav is None) else request.model.status_magic_clamav, request),
         "deleted": 0, # TODO
         "commit_id": None #  TODO
     }


### PR DESCRIPTION
While a file is still validating, checks that hadn't run yet were showing the grey
"not validated" icon instead of the hourglass. This makes them look skipped when they
were really just still pending. Now they show the hourglass until the run is actually
finished, then settle to their real result (green/red/grey).

The fix waits for the validation's *status* to say it's done,
because the bar reaches 100% a moment before the run truly finishes. It's a
backend-only change (the frontend already knows how to draw the hourglass), so it
fixes this everywhere the statuses are shown, not just the dashboard.